### PR TITLE
update docs to address idk featurebase split in tarball

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,54 +9,63 @@ This welcome guide is designed to get you started using FeatureBase on a Mac or 
 If you are using Windows, you may [build the binary](https://github.com/featurebasedb/featureBase/#build-featurebase-server-from-source) yourself or use our [cloud trial](https://cloud.featurebase.com/signup).
 
 ## Install (Mac or Linux)
-Start by heading over to the [downloads](https://github.com/FeatureBaseDB/FeatureBase/releases) on the [Github repo](https://github.com/FeatureBaseDB/featurebase) and select the build needed for your particular architecture. The ARM version are for newer Macs or devices like the Raspberry Pi. The AMD versions are for Intel architectures.
+Start by heading over to the [downloads](https://github.com/FeatureBaseDB/FeatureBase/releases) on the [Github repo](https://github.com/FeatureBaseDB/featurebase) and select the builds needed for your particular architecture. The ARM versions are for newer Macs or devices like the Raspberry Pi. The AMD versions are for Intel architectures.
 
-From here on, we'll assume you are using the v1.1.0 ARM version on a newer macOS-based machine. Keep in mind there may be newer versions of the software available.
+**NOTE:**
+Be sure to download the corresponding IDK builds. They are used for ingesting data into the FeatureBase binary.
+
+From here on, we'll assume you are using the v1.2.0 ARM versions on a newer macOS-based machine. Keep in mind there may be newer versions of the software available.
 
 Open a terminal and move into the directory where you downloaded FeatureBase. Copy and paste these commands to create a new directory and move the tarball into it:
 
 ```
-mkdir featurebase
-mv featurebase-*.tar.gz featurebase
-cd featurebase
+mkdir ~/featurebase
+mv featurebase-*.tar.gz ~/featurebase
+mv idk-*.tar.gz* ~/featurebase
+cd ~/featurebase
 ```
 
 **OUTPUT:**
 ```
 kord@bob Downloads % mkdir featurebase
 kord@bob Downloads % mv featurebase-*.tar.gz featurebase
+kord@bob Downloads % mv idk-*.tar.gz featurebase
 kord@bob Downloads % cd featurebase
 kord@bob featurebase % ls
-featurebase-v1.1.0-community-darwin-arm64.tar.gz
+featurebase-v1.2.0-community-darwin-arm64.tar.gz
+idk-v1.2.0-community-darwin-arm64.tar.gz.tar
 ```
 
-Now use `tar` to uncompress the file:
+Now use `tar` to uncompress the files:
 
 ```
 tar xvfz featurebase-*-arm64.tar.gz
+tar xvfz idk-*-arm64.tar.gz*
 ```
 
 **OUTPUT:**
 ```
 kord@bob featurebase % tar xvfz featurebase-*-arm64.tar.gz
-x featurebase-v1.1.0-community-darwin-arm64/
-x featurebase-v1.1.0-community-darwin-arm64/featurebase.redhat.service
-x featurebase-v1.1.0-community-darwin-arm64/NOTICE
-x featurebase-v1.1.0-community-darwin-arm64/featurebase
-x featurebase-v1.1.0-community-darwin-arm64/featurebase.debian.service
-x featurebase-v1.1.0-community-darwin-arm64/featurebase.conf
-x idk-v1.1.0-community-darwin-arm64/
-x idk-v1.1.0-community-darwin-arm64/molecula-consumer-github
-x idk-v1.1.0-community-darwin-arm64/molecula-consumer-sql
-x idk-v1.1.0-community-darwin-arm64/molecula-consumer-csv
-x idk-v1.1.0-community-darwin-arm64/molecula-consumer-kafka-static
-x idk-v1.1.0-community-darwin-arm64/molecula-consumer-kinesis
+x featurebase-v1.2.0-community-darwin-arm64/
+x featurebase-v1.2.0-community-darwin-arm64/featurebase.redhat.service
+x featurebase-v1.2.0-community-darwin-arm64/NOTICE
+x featurebase-v1.2.0-community-darwin-arm64/featurebase
+x featurebase-v1.2.0-community-darwin-arm64/featurebase.debian.service
+x featurebase-v1.2.0-community-darwin-arm64/featurebase.conf
+
+kord@bob featurebase % tar xvfz idk-*-arm64.tar.gz*
+x idk-v3.23.0-darwin-arm64/
+x idk-v3.23.0-darwin-arm64/molecula-consumer-kinesis
+x idk-v3.23.0-darwin-arm64/molecula-consumer-csv
+x idk-v3.23.0-darwin-arm64/molecula-consumer-kafka-static
+x idk-v3.23.0-darwin-arm64/molecula-consumer-sql
+x idk-v3.23.0-darwin-arm64/molecula-consumer-github
 ```
 
 Let's move the directories into something that's a little easier to type:
 
 ```
-mv featurebase-*-community-darwin-arm64/ opt
+mv featurebase-*-arm64/ opt
 mv idk-*-arm64 idk
 ```
 
@@ -66,11 +75,18 @@ kord@bob featurebase % mv featurebase-*-community-darwin-arm64/ opt
 kord@bob featurebase % mv idk-*-arm64 idk
 ```
 
+Now remove the offending tarballs (optional AND BE CAREFUL WITH THIS):
+
+```
+rm *.gz*
+```
+
 Let's check the directory structure:
 
 ```
-kord@bob featurebase % ls
-opt    idk
+kord@bob featurebase % ls -lah
+drwxr-xr-x@ 7 kord  staff   224B Oct 28 12:19 idk
+drwxr-xr-x@ 7 kord  staff   224B Oct 28 12:19 opt
 ```
 
 **NOTE:**
@@ -88,26 +104,30 @@ xattr -d com.apple.quarantine idk/*
 Start the server by changing into the `opt` directory and running `./featurebase server`:
 
 ```
-kord@bob ~ % cd ~/Downloads/featurebase/opt
-kord@bob fb % ./featurebase server
-2022-09-30T21:26:19.033157Z INFO:  Molecula Pilosa v1.1.0-community (Sep 30 2022 3:26PM, e75abc3c) go1.19.1
-2022-09-30T21:26:19.036403Z INFO:  rbf config = &cfg.Config{MaxSize:4294967296, MaxWALSize:4294967296, MinWALCheckpointSize:1048576, MaxWALCheckpointSize:2147483648, FsyncEnabled:true, FsyncWALEnabled:true, DoAllocZero:false, CursorCacheSize:0, Logger:logger.Logger(nil), MaxDelete:65536}
-2022-09-30T21:26:19.036432Z INFO:  cwd: /Users/kord/code/scratch/opt
-2022-09-30T21:26:19.036436Z INFO:  cmd line: ./featurebase server
-2022-09-30T21:26:19.094964Z INFO:  enabled Web UI at :10101
-2022-09-30T21:26:19.095062Z INFO:  open server. PID 90764
-2022-09-30T21:26:20.926742Z INFO:  open holder path: /Users/kord/.pilosa
-2022-09-30T21:26:20.926914Z INFO:  holder translation sync monitor initializing
-2022-09-30T21:26:20.927158Z INFO:  holder translation sync beginning
-2022-09-30T21:26:25.889248Z INFO:  diagnostics disabled
-2022-09-30T21:26:25.889287Z INFO:  listening as http://localhost:10101
-2022-09-30T21:26:25.889300Z INFO:  start initial cluster state sync
-2022-09-30T21:26:25.889312Z INFO:  completed initial cluster state sync in 19.875µs
-2022-09-30T21:26:25.889359Z INFO:  enabled grpc listening on 127.0.0.1:20101
+kord@bob opt % ./featurebase server
+2022-10-28T19:59:50.223833Z INFO:  Molecula Pilosa v1.2.0-community (Oct 28 2022 12:19PM, daceee2a) go1.19.1
+2022-10-28T19:59:50.230339Z INFO:  rbf config = &cfg.Config{MaxSize:4294967296, MaxWALSize:4294967296, MinWALCheckpointSize:1048576, MaxWALCheckpointSize:2147483648, FsyncEnabled:true, FsyncWALEnabled:true, DoAllocZero:false, CursorCacheSize:0, Logger:logger.Logger(nil), MaxDelete:65536}
+2022-10-28T19:59:50.230372Z INFO:  cwd: /Users/kord/featurebase/opt
+2022-10-28T19:59:50.230375Z INFO:  cmd line: ./featurebase server
+2022-10-28T19:59:50.233328Z INFO:  open server. PID 58251
+2022-10-28T19:59:51.579041Z INFO:  open holder path: /Users/kord/.pilosa
+2022-10-28T19:59:51.579095Z INFO:  holder translation sync monitor initializing
+2022-10-28T19:59:51.579114Z INFO:  holder translation sync beginning
+2022-10-28T19:59:51.598429Z INFO:  opening index: allyourbase
+2022-10-28T19:59:51.777437Z INFO:  open holder: complete
+2022-10-28T19:59:51.778019Z INFO:  diagnostics disabled
+2022-10-28T19:59:51.778111Z INFO:  listening as http://localhost:10101
+2022-10-28T19:59:51.778202Z INFO:  start initial cluster state sync
+2022-10-28T19:59:51.778219Z INFO:  completed initial cluster state sync in 37.959µs
+2022-10-28T19:59:51.778278Z INFO:  enabled grpc listening on 127.0.0.1:20101
 ```
 
 **NOTE:**
-Pilosa is the older name of the FeatureBase server, which was created by Molecula (DBA FeatureBase). Pilosas are an order of xenarthran placental mammals, native to the Americas. It includes the anteaters and sloths, which includes the extinct ground sloths. The name comes from the Latin word for "hairy".
+Pilosa is the older name of the FeatureBase server, which was created by Molecula (DBA FeatureBase). Pilosas are an order of xenarthran placental mammals, native to the Americas. It includes the anteaters, sloths, and the extinct ground sloths. The name comes from the Latin word for "hairy".
+
+Together with the armadillos, which are in the order Cingulata, pilosans are part of the larger superorder [Xenarthra](https://en.wikipedia.org/wiki/Xenarthra).
+
+Evidently the term "pilosa" is a profanity in Italian.
 
 ## Access the UI
 Now we have the server running, open a new browser tab and access the UI using the following URL. It is recommended to use Chrome or Firefox as the UI does not work in Safari currently:
@@ -121,8 +141,8 @@ FeatureBase runs on port `10101`.
 
 ![ui](/img/welcome/localhost.png)
 
-## Ingest Data
-We're now ready to ingest data. Create a new terminal window and copy the following and paste it into a `sample.csv` file located in the `featurebase` directory:
+## Create Data
+Create a new terminal window and copy the following and paste it into a `sample.csv` file located in the `featurebase` directory under `~Documents`:
 
 ```
 asset_tag__String,fan_time__RecordTime_2006-01-02,fan_val__String_F_YMD
@@ -136,7 +156,16 @@ BEDF,2019-01-08,20%
 ABCD,2019-01-04,30%
 ```
 
-We'll use the `molecula-consumer-csv` tool (located in idk) to ingest the `sample.csv` file:
+In the terminal, you can use `pico` to edit the file:
+
+```
+kord@bob featurebase % pico sample.csv
+
+```
+
+Crtl-X in pico will quit and save. You may also use another editor of your choice.
+
+Now you have a `sample.csv` file, we'll use the `molecula-consumer-csv` tool (located in idk) to ingest the file:
 
 ```
 idk/molecula-consumer-csv \
@@ -149,23 +178,14 @@ idk/molecula-consumer-csv \
 
 ```
 kord@bob featurebase % idk/molecula-consumer-csv --auto-generate --index=allyourbase --files=gist/sample.csv
-Molecula Consumer v3.20.0, build time 2022-08-26T00:11:50+0000
-2022-09-23T20:07:25.430833Z INFO:  Serving Prometheus metrics with namespace "ingester_csv" at localhost:9093/metrics
-2022-09-23T20:07:25.434554Z INFO:  start ingester 0
-2022-09-23T20:07:25.434862Z INFO:  processFile: gist/sample.csv
-2022-09-23T20:07:25.435059Z INFO:  new schema: []idk.Field{idk.StringField{NameVal:"asset_tag", DestNameVal:"asset_tag", Mutex:false, Quantum:"", TTL:"", CacheConfig:(*idk.CacheConfig)(nil)}, idk.RecordTimeField{NameVal:"fan_time", DestNameVal:"fan_time", Layout:"2006-01-02", Epoch:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Unit:""}, idk.StringField{NameVal:"fan_val", DestNameVal:"fan_val", Mutex:false, Quantum:"YMD", TTL:"", CacheConfig:(*idk.CacheConfig)(nil)}}
-2022-09-23T20:07:25.436104Z INFO:  Listening for /debug/pprof/ and /debug/fgprof on 'localhost:6062'
-2022-09-23T20:07:25.478702Z INFO:  translating batch of 8 took: 41.931708ms
-2022-09-23T20:07:25.478805Z INFO:  making fragments for batch of 8 took 110.25µs
-2022-09-23T20:07:25.481605Z INFO:  importing fragments took 2.799375ms
-2022-09-23T20:07:25.481918Z INFO:  1 records processed 0-> (9)
-2022-09-23T20:07:25.481925Z INFO:  metrics: import=46.120541ms
-```
-
-**NOTE:** If you need to set the execute flag on the idk/ executables:
-
-```
-chmod 755 idk/*
+Molecula Consumer v3.23.0, build time 2022-10-27T23:42:47+0000
+2022-10-28T20:14:17.518462Z INFO:  setting up stats: listen for metrics on 'localhost:9093': listen tcp 127.0.0.1:9093: bind: address already in use
+2022-10-28T20:14:17.522488Z INFO:  start ingester 0
+2022-10-28T20:14:17.522956Z INFO:  processFile: sample.csv
+2022-10-28T20:14:17.523039Z INFO:  new schema: []idk.Field{idk.StringField{NameVal:"asset_tag", DestNameVal:"asset_tag", Mutex:false, Quantum:"", TTL:"", CacheConfig:(*idk.CacheConfig)(nil)}, idk.RecordTimeField{NameVal:"fan_time", DestNameVal:"fan_time", Layout:"2006-01-02", Epoch:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Unit:""}, idk.StringField{NameVal:"fan_val", DestNameVal:"fan_val", Mutex:false, Quantum:"YMD", TTL:"", CacheConfig:(*idk.CacheConfig)(nil)}}
+2022-10-28T20:14:17.531197Z INFO:  Listening for /debug/pprof/ and /debug/fgprof on 'localhost:6062'
+2022-10-28T20:14:17.944749Z INFO:  translating batch of 1 took: 92.211042ms
+2022-10-28T20:14:17.945077Z INFO:  making fragments for batch of 1 took 357.166µs
 ```
 
 ## Querying


### PR DESCRIPTION
The latest release of the community build has split the download binary into two tarballs.

One is for the featurebase binary. One is for the IDK binaries. Updated docs to reflect.